### PR TITLE
Add TypedStorage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,14 @@
 version: 2
 workflows:
   version: 2
-  test:
+  checks:
     jobs:
-      - base
+      - test
       - fmt
       - clippy
 
 jobs:
-  base:
+  test:
     docker:
       - image: rust:1.39
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ maintenance = { status = "actively-developed" }
 cosmwasm = "~0.6.0"
 serde = { version = "~1.0.103", default-features = false, features = ["derive", "alloc"] }
 snafu = { version = "~0.5.0", default-features = false, features = ["rust_1_30"] }
+named_type = "=0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ cosmwasm = "~0.6.0"
 serde = { version = "~1.0.103", default-features = false, features = ["derive", "alloc"] }
 snafu = { version = "~0.5.0", default-features = false, features = ["rust_1_30"] }
 named_type = "=0.2.1"
+named_type_derive = "=0.2.1"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ or SQL tables.
 Since we have different types for `Storage` and `ReadonlyStorage`, we use two different constructors:
 
 ```rust
-use cw_storage::{prefixed, prefixed_ro};
+use cw_storage::{prefixed, prefixed_read};
 
 let mut store = MockStorage::new();
 
@@ -33,10 +33,10 @@ foos.set(b"one", b"foo");
 let mut bars = prefixed(b"bar", &mut store);
 bars.set(b"one", b"bar");
 
-let read_foo = prefixed_ro(b"foo", &store);
+let read_foo = prefixed_read(b"foo", &store);
 assert_eq!(b"foo".to_vec(), read_foo.get(b"one").unwrap());
 
-let read_bar = prefixed_ro(b"bar", &store);
+let read_bar = prefixed_read(b"bar", &store);
 assert_eq!(b"bar".to_vec(), read_bar.get(b"one").unwrap());
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 [![CircleCI](https://circleci.com/gh/confio/cw-storage/tree/master.svg?style=shield)](https://circleci.com/gh/confio/cw-storage/tree/master) 
 
-CosmWasm library with useful helpers for Storage patterns
+CosmWasm library with useful helpers for Storage patterns.
+This is not in the core library, so feel free to fork it and modify or extend as desired for your contracts.
+Pull Requests back to upstream repo with new or improved features are always welcome.
 
 ## Contents
 
 * [PrefixedStorage](#prefixed-storage)
+* [TypedStoreage](#typed-storage)
 
 ### Prefixed Storage
 
@@ -43,3 +46,57 @@ However, if we did use `foos` again at the bottom, it would properly complain ab
 unique mutable reference. 
 
 The takeaway is to create the `PrefixedStorage` objects when needed and not to hang around to them too long.
+
+### Typed Storage
+
+As we divide our storage space into different subspaces or "buckets", we will quickly notice that each
+"bucket" works on a unique type. This leads to a lot of repeated serialization and deserialization
+boilerplate that can be removed. We do this by wrapping a `Storage` with a type-aware `TypedStorage`
+struct that provides us a higher-level access to the data. 
+
+Note that `TypedStorage` itself does not implement the `Storage` interface, so when combining 
+with `PrefixStorage`, make sure to wrap the prefix first.
+
+```rust
+use cosmwasm::mock::MockStorage;
+use cw_storage::{prefixed, typed};
+
+let mut store = MockStorage::new();
+let mut space = prefixed(b"data", &mut store);
+let mut bucket = typed::<_, Data>(&mut space);
+
+// save data
+let data = Data {
+    name: "Maria".to_string(),
+    age: 42,
+};
+bucket.save(b"maria", &data).unwrap();
+
+// load it properly
+let loaded = bucket.load(b"maria").unwrap();
+assert_eq!(data, loaded);
+
+// loading empty can return Ok(None) or Err depending on the chosen method:
+assert!(bucket.load(b"john").is_err());
+assert_eq!(bucket.may_load(b"john"), Ok(None));
+```
+
+Beyond the basic `save`, `load`, and `may_load`, there is a higher-level API exposed, `update`.
+`Update` will load the data, apply an operation and save it again (if the operation was successful).
+It will also return any error that occurred, or the final state that was written if successful.
+
+```rust
+let birthday = |mut d: Data| {
+    d.age += 1;
+    Ok(d)
+};
+let output = bucket.update(b"maria", &birthday).unwrap();
+let expected = Data {
+    name: "Maria".to_string(),
+    age: 43,
+};
+assert_eq!(output, expected);
+``` 
+
+Since the heart of much of the smart contract code is simply transformations upon some stored state,
+We may be able to just code the transforms and let the `TypedStorage` APIs take care of all the boilerplate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,4 @@ mod prefix;
 mod typed;
 
 pub use prefix::{prefixed, prefixed_ro, PrefixedStorage, ReadonlyPrefixedStorage};
-pub use typed::{typed, TypedStorage};
+pub use typed::{typed, typed_read, ReadonlyTypedStorage, TypedStorage};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 mod prefix;
 mod typed;
 
-pub use prefix::{prefixed, prefixed_ro, PrefixedStorage, ReadonlyPrefixedStorage};
+pub use prefix::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 pub use typed::{typed, typed_read, ReadonlyTypedStorage, TypedStorage};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,4 @@ mod prefix;
 mod typed;
 
 pub use prefix::{prefixed, prefixed_ro, PrefixedStorage, ReadonlyPrefixedStorage};
-pub use typed::TypedStorage;
+pub use typed::{typed, TypedStorage};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
 mod prefix;
+mod typed;
 
 pub use prefix::{prefixed, prefixed_ro, PrefixedStorage, ReadonlyPrefixedStorage};
+pub use typed::TypedStorage;

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -1,7 +1,7 @@
 use cosmwasm::traits::{ReadonlyStorage, Storage};
 
-// prefixed_ro is a helper function for less verbose usage
-pub fn prefixed_ro<'a, T: ReadonlyStorage>(
+// prefixed_read is a helper function for less verbose usage
+pub fn prefixed_read<'a, T: ReadonlyStorage>(
     prefix: &[u8],
     storage: &'a T,
 ) -> ReadonlyPrefixedStorage<'a, T> {

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -7,14 +7,14 @@ use cosmwasm::errors::{ContractErr, ParseErr, Result, SerializeErr};
 use cosmwasm::serde::{from_slice, to_vec};
 use cosmwasm::traits::{ReadonlyStorage, Storage};
 
-pub fn typed<'a, S: Storage, T>(storage: &'a mut S) -> TypedStorage<'a, S, T>
+pub fn typed<S: Storage, T>(storage: &mut S) -> TypedStorage<S, T>
 where
     T: Serialize + DeserializeOwned + NamedType,
 {
     TypedStorage::new(storage)
 }
 
-pub fn typed_read<'a, S: ReadonlyStorage, T>(storage: &'a S) -> ReadonlyTypedStorage<'a, S, T>
+pub fn typed_read<S: ReadonlyStorage, T>(storage: &S) -> ReadonlyTypedStorage<S, T>
 where
     T: Serialize + DeserializeOwned + NamedType,
 {
@@ -167,7 +167,7 @@ mod test {
         };
         bucket.save(b"maria", &data).unwrap();
 
-        let mut reader = typed_read::<_, Data>(&mut store);
+        let reader = typed_read::<_, Data>(&mut store);
 
         // check empty data handling
         assert!(reader.load(b"john").is_err());

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -1,0 +1,58 @@
+use named_type::NamedType;
+use serde::{de::DeserializeOwned, ser::Serialize};
+use snafu::{OptionExt, ResultExt};
+use std::marker::PhantomData;
+
+use cosmwasm::errors::{ContractErr, ParseErr, Result, SerializeErr};
+use cosmwasm::serde::{from_slice, to_vec};
+use cosmwasm::traits::Storage;
+use snafu::futures01::FutureExt;
+
+pub struct TypedStorage<'a, S: Storage, T>
+where
+    T: Serialize + DeserializeOwned + NamedType,
+{
+    storage: &'a mut S,
+    // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
+    data: PhantomData<&'a T>,
+}
+
+impl<'a, S: Storage, T> TypedStorage<'a, S, T>
+where
+    T: Serialize + DeserializeOwned + NamedType,
+{
+    pub fn new(storage: &'a mut S) -> Self {
+        TypedStorage {
+            storage,
+            data: PhantomData,
+        }
+    }
+
+    /// save will serialize the model and store, returns an error on serialization issues
+    pub fn save(&mut self, key: &[u8], data: &T) -> Result<()> {
+        let bz = to_vec(data).context(SerializeErr {
+            kind: T::short_type_name(),
+        })?;
+        self.storage.set(key, &bz);
+        Ok(())
+    }
+
+    /// load will return an error if no data is set at the given key, or on parse error
+    pub fn load(&mut self, key: &[u8]) -> Result<T> {
+        self.may_load(key)?.context(ContractErr {
+            msg: "uninitialized data",
+        })
+    }
+
+    /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
+    /// returns an error on issues parsing
+    pub fn may_load(&mut self, key: &[u8]) -> Result<Option<T>> {
+        let bz = self.storage.get(key);
+        match bz {
+            Some(d) => from_slice(&d).context(ParseErr {
+                kind: T::short_type_name(),
+            }),
+            None => Ok(None),
+        }
+    }
+}

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -52,6 +52,7 @@ where
 
     /// load will return an error if no data is set at the given key, or on parse error
     pub fn load(&self, key: &[u8]) -> Result<T> {
+        // TODO: replace with NotFound with cosmwasm 0.6.1
         self.may_load(key)?.context(ContractErr {
             msg: "uninitialized data",
         })
@@ -60,8 +61,7 @@ where
     /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
     /// returns an error on issues parsing
     pub fn may_load(&self, key: &[u8]) -> Result<Option<T>> {
-        let bz = self.storage.get(key);
-        match bz {
+        match self.storage.get(key) {
             Some(d) => from_slice(&d).context(ParseErr {
                 kind: T::short_type_name(),
             }),
@@ -103,6 +103,7 @@ where
 
     /// load will return an error if no data is set at the given key, or on parse error
     pub fn load(&self, key: &[u8]) -> Result<T> {
+        // TODO: replace with NotFound with cosmwasm 0.6.1
         self.may_load(key)?.context(ContractErr {
             msg: "uninitialized data",
         })
@@ -111,8 +112,7 @@ where
     /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
     /// returns an error on issues parsing
     pub fn may_load(&self, key: &[u8]) -> Result<Option<T>> {
-        let bz = self.storage.get(key);
-        match bz {
+        match self.storage.get(key) {
             Some(d) => from_slice(&d).context(ParseErr {
                 kind: T::short_type_name(),
             }),

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -7,6 +7,13 @@ use cosmwasm::errors::{ContractErr, ParseErr, Result, SerializeErr};
 use cosmwasm::serde::{from_slice, to_vec};
 use cosmwasm::traits::Storage;
 
+pub fn typed<'a, S: Storage, T>(storage: &'a mut S) -> TypedStorage<'a, S, T>
+where
+    T: Serialize + DeserializeOwned + NamedType,
+{
+    TypedStorage::new(storage)
+}
+
 pub struct TypedStorage<'a, S: Storage, T>
 where
     T: Serialize + DeserializeOwned + NamedType,
@@ -54,6 +61,17 @@ where
             None => Ok(None),
         }
     }
+
+    /// update will load the data, perform the specified action, and store the result
+    /// in the database. This is shorthand for some common sequences, which may be useful
+    ///
+    /// This is the least stable of the APIs, and definitely needs some usage
+    pub fn update(&mut self, key: &[u8], action: &dyn Fn(T) -> Result<T>) -> Result<T> {
+        let input = self.load(key)?;
+        let output = action(input)?;
+        self.save(key, &output)?;
+        Ok(output)
+    }
 }
 
 #[cfg(test)]
@@ -88,5 +106,78 @@ mod test {
         // load it properly
         let loaded = bucket.load(b"maria").unwrap();
         assert_eq!(data, loaded);
+    }
+
+    #[test]
+    fn update_success() {
+        let mut store = MockStorage::new();
+        let mut bucket = typed::<_, Data>(&mut store);
+
+        // initial data
+        let init = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        bucket.save(b"maria", &init).unwrap();
+
+        // it's my birthday
+        let output = bucket
+            .update(b"maria", &|mut d| {
+                d.age += 1;
+                Ok(d)
+            })
+            .unwrap();
+        let expected = Data {
+            name: "Maria".to_string(),
+            age: 43,
+        };
+        assert_eq!(output, expected);
+
+        // load it properly
+        let loaded = bucket.load(b"maria").unwrap();
+        assert_eq!(loaded, expected);
+    }
+
+    #[test]
+    fn update_fails_on_error() {
+        let mut store = MockStorage::new();
+        let mut bucket = typed::<_, Data>(&mut store);
+
+        // initial data
+        let init = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        bucket.save(b"maria", &init).unwrap();
+
+        // it's my birthday
+        let output = bucket.update(b"maria", &|_d| {
+            ContractErr {
+                msg: "cuz i feel like it",
+            }
+            .fail()
+        });
+        assert!(output.is_err());
+
+        // load it properly
+        let loaded = bucket.load(b"maria").unwrap();
+        assert_eq!(loaded, init);
+    }
+
+    #[test]
+    fn update_fails_on_no_data() {
+        let mut store = MockStorage::new();
+        let mut bucket = typed::<_, Data>(&mut store);
+
+        // it's my birthday
+        let output = bucket.update(b"maria", &|mut d| {
+            d.age += 1;
+            Ok(d)
+        });
+        assert!(output.is_err());
+
+        // nothing stored
+        let loaded = bucket.may_load(b"maria").unwrap();
+        assert_eq!(loaded, None);
     }
 }

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -60,8 +60,8 @@ where
 mod test {
     use super::*;
     use cosmwasm::mock::MockStorage;
-    use serde::{Serialize, Deserialize};
     use named_type_derive::NamedType;
+    use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, NamedType, PartialEq, Debug)]
     struct Data {
@@ -79,7 +79,10 @@ mod test {
         assert_eq!(bucket.may_load(b"maria").unwrap(), None);
 
         // save data
-        let data = Data{name: "Maria".to_string(), age: 42};
+        let data = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
         bucket.save(b"maria", &data).unwrap();
 
         // load it properly


### PR DESCRIPTION
Closes #1 

This is a helper to enforce properly typed data in a storage bucket.
Along with `PrefixStorage` this takes care of much of the boilerplate for reading and writing data in smart contracts.