### PR TITLE
WIP: Bucket refactor

### DIFF
--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,31 +1,77 @@
-//use named_type::NamedType;
-//use serde::{de::DeserializeOwned, ser::Serialize};
-//
-//use cosmwasm::traits::Storage;
-//use crate::{PrefixedStorage, TypedStorage};
-//
-//pub fn bucket<'a, S: Storage, T>(namespace: &[u8], storage: &'a mut S) -> Bucket<'a, S, T>
-//    where
-//        T: Serialize + DeserializeOwned + NamedType,
-//{
-//    Bucket::new(namespace, storage)
-//}
-//
-//pub struct Bucket<'a, S: Storage, T>
-//    where
-//        T: Serialize + DeserializeOwned + NamedType,
-//{
-//    prefix: PrefixedStorage<'a, S>,
-//    typed: TypedStorage<'a, PrefixedStorage<'a, S>, T>,
-//}
-//
-//impl<'a, S: Storage, T> Bucket<'a, S, T>
-//    where
-//        T: Serialize + DeserializeOwned + NamedType,
-//{
-//    pub fn new(namespace: &[u8], storage: &'a mut S) -> Self {
-//        let mut prefix = PrefixedStorage::new(namespace, storage);
-//        let typed = TypedStorage::<_, T>::new(&mut prefix);
-//        Bucket { prefix, typed }
-//    }
-//}
+use named_type::NamedType;
+use serde::{de::DeserializeOwned, ser::Serialize};
+use std::marker::PhantomData;
+
+use cosmwasm::errors::Result;
+use cosmwasm::traits::Storage;
+
+use crate::namespace_helpers::{get_with_prefix, key_prefix, key_prefix_nested, set_with_prefix};
+use crate::type_helpers::{deserialize, may_deserialize, serialize};
+
+pub fn bucket<'a, S: Storage, T>(namespace: &[u8], storage: &'a mut S) -> Bucket<'a, S, T>
+where
+    T: Serialize + DeserializeOwned + NamedType,
+{
+    Bucket::new(namespace, storage)
+}
+
+pub struct Bucket<'a, S: Storage, T>
+where
+    T: Serialize + DeserializeOwned + NamedType,
+{
+    storage: &'a mut S,
+    // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
+    data: PhantomData<&'a T>,
+    prefix: Vec<u8>,
+}
+
+impl<'a, S: Storage, T> Bucket<'a, S, T>
+where
+    T: Serialize + DeserializeOwned + NamedType,
+{
+    pub fn new(namespace: &[u8], storage: &'a mut S) -> Self {
+        Bucket {
+            prefix: key_prefix(namespace),
+            storage,
+            data: PhantomData,
+        }
+    }
+
+    pub fn multilevel(namespaces: &[&[u8]], storage: &'a mut S) -> Self {
+        Bucket {
+            prefix: key_prefix_nested(namespaces),
+            storage,
+            data: PhantomData,
+        }
+    }
+
+    /// save will serialize the model and store, returns an error on serialization issues
+    pub fn save(&mut self, key: &[u8], data: &T) -> Result<()> {
+        set_with_prefix(self.storage, &self.prefix, key, &serialize(data)?);
+        Ok(())
+    }
+
+    /// load will return an error if no data is set at the given key, or on parse error
+    pub fn load(&self, key: &[u8]) -> Result<T> {
+        let value = get_with_prefix(self.storage, &self.prefix, key);
+        deserialize(&value)
+    }
+
+    /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
+    /// returns an error on issues parsing
+    pub fn may_load(&self, key: &[u8]) -> Result<Option<T>> {
+        let value = get_with_prefix(self.storage, &self.prefix, key);
+        may_deserialize(&value)
+    }
+
+    /// update will load the data, perform the specified action, and store the result
+    /// in the database. This is shorthand for some common sequences, which may be useful
+    ///
+    /// This is the least stable of the APIs, and definitely needs some usage
+    pub fn update(&mut self, key: &[u8], action: &dyn Fn(T) -> Result<T>) -> Result<T> {
+        let input = self.load(key)?;
+        let output = action(input)?;
+        self.save(key, &output)?;
+        Ok(output)
+    }
+}

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,0 +1,31 @@
+//use named_type::NamedType;
+//use serde::{de::DeserializeOwned, ser::Serialize};
+//
+//use cosmwasm::traits::Storage;
+//use crate::{PrefixedStorage, TypedStorage};
+//
+//pub fn bucket<'a, S: Storage, T>(namespace: &[u8], storage: &'a mut S) -> Bucket<'a, S, T>
+//    where
+//        T: Serialize + DeserializeOwned + NamedType,
+//{
+//    Bucket::new(namespace, storage)
+//}
+//
+//pub struct Bucket<'a, S: Storage, T>
+//    where
+//        T: Serialize + DeserializeOwned + NamedType,
+//{
+//    prefix: PrefixedStorage<'a, S>,
+//    typed: TypedStorage<'a, PrefixedStorage<'a, S>, T>,
+//}
+//
+//impl<'a, S: Storage, T> Bucket<'a, S, T>
+//    where
+//        T: Serialize + DeserializeOwned + NamedType,
+//{
+//    pub fn new(namespace: &[u8], storage: &'a mut S) -> Self {
+//        let mut prefix = PrefixedStorage::new(namespace, storage);
+//        let typed = TypedStorage::<_, T>::new(&mut prefix);
+//        Bucket { prefix, typed }
+//    }
+//}

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -6,7 +6,7 @@ use cosmwasm::errors::Result;
 use cosmwasm::traits::Storage;
 
 use crate::namespace_helpers::{get_with_prefix, key_prefix, key_prefix_nested, set_with_prefix};
-use crate::type_helpers::{deserialize, may_deserialize, serialize};
+use crate::type_helpers::{may_deserialize, must_deserialize, serialize};
 
 pub fn bucket<'a, S: Storage, T>(namespace: &[u8], storage: &'a mut S) -> Bucket<'a, S, T>
 where
@@ -54,7 +54,7 @@ where
     /// load will return an error if no data is set at the given key, or on parse error
     pub fn load(&self, key: &[u8]) -> Result<T> {
         let value = get_with_prefix(self.storage, &self.prefix, key);
-        deserialize(&value)
+        must_deserialize(&value)
     }
 
     /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod singleton;
 mod type_helpers;
 mod typed;
 
+pub use bucket::{bucket, Bucket};
 pub use prefix::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 pub use sequence::{currval, nextval, sequence, SeqVal};
 pub use singleton::{singleton, singleton_read, ReadonlySingleton, Singleton};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+mod bucket;
+mod namespace_helpers;
 mod prefix;
 mod sequence;
 mod singleton;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod singleton;
 mod type_helpers;
 mod typed;
 
-pub use bucket::{bucket, Bucket};
+pub use bucket::{bucket, bucket_read, Bucket, ReadonlyBucket};
 pub use prefix::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 pub use sequence::{currval, nextval, sequence, SeqVal};
 pub use singleton::{singleton, singleton_read, ReadonlySingleton, Singleton};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,5 @@ pub use bucket::{bucket, Bucket};
 pub use prefix::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 pub use sequence::{currval, nextval, sequence, SeqVal};
 pub use singleton::{singleton, singleton_read, ReadonlySingleton, Singleton};
-pub use type_helpers::{deserialize, may_deserialize, serialize};
+pub use type_helpers::{deserialize, serialize};
 pub use typed::{typed, typed_read, ReadonlyTypedStorage, TypedStorage};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,11 @@ mod namespace_helpers;
 mod prefix;
 mod sequence;
 mod singleton;
+mod type_helpers;
 mod typed;
 
 pub use prefix::{prefixed, prefixed_read, PrefixedStorage, ReadonlyPrefixedStorage};
 pub use sequence::{currval, nextval, sequence, SeqVal};
 pub use singleton::{singleton, singleton_read, ReadonlySingleton, Singleton};
+pub use type_helpers::{deserialize, may_deserialize, serialize};
 pub use typed::{typed, typed_read, ReadonlyTypedStorage, TypedStorage};

--- a/src/namespace_helpers.rs
+++ b/src/namespace_helpers.rs
@@ -1,0 +1,91 @@
+// Calculates the raw key prefix for a given namespace
+// as documented in https://github.com/webmaster128/key-namespacing#length-prefixed-keys
+pub(crate) fn key_prefix(namespace: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(namespace.len() + 2);
+    extend_with_prefix(&mut out, namespace);
+    out
+}
+
+// Calculates the raw key prefix for a given nested namespace
+// as documented in https://github.com/webmaster128/key-namespacing#nesting
+pub(crate) fn key_prefix_nested(namespaces: &[&[u8]]) -> Vec<u8> {
+    let mut size = namespaces.len();
+    for &namespace in namespaces {
+        size += namespace.len() + 2;
+    }
+
+    let mut out = Vec::with_capacity(size);
+    for &namespace in namespaces {
+        extend_with_prefix(&mut out, namespace);
+    }
+    out
+}
+
+// extend_with_prefix is only for internal use to unify key_prefix and key_prefix_nested efficiently
+// as documented in https://github.com/webmaster128/key-namespacing#nesting
+fn extend_with_prefix(out: &mut Vec<u8>, namespace: &[u8]) {
+    out.extend_from_slice(&key_len(namespace));
+    out.extend_from_slice(namespace);
+}
+
+// returns the length as a 2 byte big endian encoded integer
+fn key_len(prefix: &[u8]) -> [u8; 2] {
+    if prefix.len() > 0xFFFF {
+        panic!("only supports namespaces up to length 0xFFFF")
+    }
+    let length_bytes = (prefix.len() as u64).to_be_bytes();
+    [length_bytes[6], length_bytes[7]]
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn key_prefix_works() {
+        assert_eq!(key_prefix(b""), b"\x00\x00");
+        assert_eq!(key_prefix(b"a"), b"\x00\x01a");
+        assert_eq!(key_prefix(b"ab"), b"\x00\x02ab");
+        assert_eq!(key_prefix(b"abc"), b"\x00\x03abc");
+    }
+
+    #[test]
+    fn key_prefix_works_for_long_prefix() {
+        let long_namespace1 = vec![0; 256];
+        let prefix1 = key_prefix(&long_namespace1);
+        assert_eq!(prefix1.len(), 256 + 2);
+        assert_eq!(&prefix1[0..2], b"\x01\x00");
+
+        let long_namespace2 = vec![0; 30000];
+        let prefix2 = key_prefix(&long_namespace2);
+        assert_eq!(prefix2.len(), 30000 + 2);
+        assert_eq!(&prefix2[0..2], b"\x75\x30");
+
+        let long_namespace3 = vec![0; 0xFFFF];
+        let prefix3 = key_prefix(&long_namespace3);
+        assert_eq!(prefix3.len(), 0xFFFF + 2);
+        assert_eq!(&prefix3[0..2], b"\xFF\xFF");
+    }
+
+    #[test]
+    #[should_panic(expected = "only supports namespaces up to length 0xFFFF")]
+    fn key_prefix_panics_for_too_long_prefix() {
+        let limit = 0xFFFF;
+        let long_namespace = vec![0; limit + 1];
+        key_prefix(&long_namespace);
+    }
+
+    #[test]
+    fn key_prefix_nested_works() {
+        assert_eq!(key_prefix_nested(&[]), b"");
+        assert_eq!(key_prefix_nested(&[b""]), b"\x00\x00");
+        assert_eq!(key_prefix_nested(&[b"", b""]), b"\x00\x00\x00\x00");
+
+        assert_eq!(key_prefix_nested(&[b"a"]), b"\x00\x01a");
+        assert_eq!(key_prefix_nested(&[b"a", b"ab"]), b"\x00\x01a\x00\x02ab");
+        assert_eq!(
+            key_prefix_nested(&[b"a", b"ab", b"abc"]),
+            b"\x00\x01a\x00\x02ab\x00\x03abc"
+        );
+    }
+}

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -1,5 +1,7 @@
 use cosmwasm::traits::{ReadonlyStorage, Storage};
 
+use crate::namespace_helpers::{key_prefix, key_prefix_nested};
+
 // prefixed_read is a helper function for less verbose usage
 pub fn prefixed_read<'a, T: ReadonlyStorage>(
     prefix: &[u8],
@@ -83,99 +85,10 @@ impl<'a, T: Storage> Storage for PrefixedStorage<'a, T> {
     }
 }
 
-// Calculates the raw key prefix for a given namespace
-// as documented in https://github.com/webmaster128/key-namespacing#length-prefixed-keys
-//
-// This is pub(crate) for use in singleton
-pub(crate) fn key_prefix(namespace: &[u8]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(namespace.len() + 2);
-    extend_with_prefix(&mut out, namespace);
-    out
-}
-
-// Calculates the raw key prefix for a given nested namespace
-// as documented in https://github.com/webmaster128/key-namespacing#nesting
-fn key_prefix_nested(namespaces: &[&[u8]]) -> Vec<u8> {
-    let mut size = namespaces.len();
-    for &namespace in namespaces {
-        size += namespace.len() + 2;
-    }
-
-    let mut out = Vec::with_capacity(size);
-    for &namespace in namespaces {
-        extend_with_prefix(&mut out, namespace);
-    }
-    out
-}
-
-// extend_with_prefix is only for internal use to unify key_prefix and key_prefix_nested efficiently
-// as documented in https://github.com/webmaster128/key-namespacing#nesting
-fn extend_with_prefix(out: &mut Vec<u8>, namespace: &[u8]) {
-    out.extend_from_slice(&key_len(namespace));
-    out.extend_from_slice(namespace);
-}
-
-// returns the length as a 2 byte big endian encoded integer
-fn key_len(prefix: &[u8]) -> [u8; 2] {
-    if prefix.len() > 0xFFFF {
-        panic!("only supports namespaces up to length 0xFFFF")
-    }
-    let length_bytes = (prefix.len() as u64).to_be_bytes();
-    [length_bytes[6], length_bytes[7]]
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
     use cosmwasm::mock::MockStorage;
-
-    #[test]
-    fn key_prefix_works() {
-        assert_eq!(key_prefix(b""), b"\x00\x00");
-        assert_eq!(key_prefix(b"a"), b"\x00\x01a");
-        assert_eq!(key_prefix(b"ab"), b"\x00\x02ab");
-        assert_eq!(key_prefix(b"abc"), b"\x00\x03abc");
-    }
-
-    #[test]
-    fn key_prefix_works_for_long_prefix() {
-        let long_namespace1 = vec![0; 256];
-        let prefix1 = key_prefix(&long_namespace1);
-        assert_eq!(prefix1.len(), 256 + 2);
-        assert_eq!(&prefix1[0..2], b"\x01\x00");
-
-        let long_namespace2 = vec![0; 30000];
-        let prefix2 = key_prefix(&long_namespace2);
-        assert_eq!(prefix2.len(), 30000 + 2);
-        assert_eq!(&prefix2[0..2], b"\x75\x30");
-
-        let long_namespace3 = vec![0; 0xFFFF];
-        let prefix3 = key_prefix(&long_namespace3);
-        assert_eq!(prefix3.len(), 0xFFFF + 2);
-        assert_eq!(&prefix3[0..2], b"\xFF\xFF");
-    }
-
-    #[test]
-    #[should_panic(expected = "only supports namespaces up to length 0xFFFF")]
-    fn key_prefix_panics_for_too_long_prefix() {
-        let limit = 0xFFFF;
-        let long_namespace = vec![0; limit + 1];
-        key_prefix(&long_namespace);
-    }
-
-    #[test]
-    fn key_prefix_nested_works() {
-        assert_eq!(key_prefix_nested(&[]), b"");
-        assert_eq!(key_prefix_nested(&[b""]), b"\x00\x00");
-        assert_eq!(key_prefix_nested(&[b"", b""]), b"\x00\x00\x00\x00");
-
-        assert_eq!(key_prefix_nested(&[b"a"]), b"\x00\x01a");
-        assert_eq!(key_prefix_nested(&[b"a", b"ab"]), b"\x00\x01a\x00\x02ab");
-        assert_eq!(
-            key_prefix_nested(&[b"a", b"ab", b"abc"]),
-            b"\x00\x01a\x00\x02ab\x00\x03abc"
-        );
-    }
 
     #[test]
     fn prefix_safe() {

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -1,6 +1,6 @@
 use cosmwasm::traits::{ReadonlyStorage, Storage};
 
-use crate::namespace_helpers::{key_prefix, key_prefix_nested};
+use crate::namespace_helpers::{get_with_prefix, key_prefix, key_prefix_nested, set_with_prefix};
 
 // prefixed_read is a helper function for less verbose usage
 pub fn prefixed_read<'a, T: ReadonlyStorage>(
@@ -40,9 +40,7 @@ impl<'a, T: ReadonlyStorage> ReadonlyPrefixedStorage<'a, T> {
 
 impl<'a, T: ReadonlyStorage> ReadonlyStorage for ReadonlyPrefixedStorage<'a, T> {
     fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        let mut k = self.prefix.clone();
-        k.extend_from_slice(key);
-        self.storage.get(&k)
+        get_with_prefix(self.storage, &self.prefix, key)
     }
 }
 
@@ -71,17 +69,13 @@ impl<'a, T: Storage> PrefixedStorage<'a, T> {
 
 impl<'a, T: Storage> ReadonlyStorage for PrefixedStorage<'a, T> {
     fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        let mut k = self.prefix.clone();
-        k.extend_from_slice(key);
-        self.storage.get(&k)
+        get_with_prefix(self.storage, &self.prefix, key)
     }
 }
 
 impl<'a, T: Storage> Storage for PrefixedStorage<'a, T> {
     fn set(&mut self, key: &[u8], value: &[u8]) {
-        let mut k = self.prefix.clone();
-        k.extend_from_slice(key);
-        self.storage.set(&k, value)
+        set_with_prefix(self.storage, &self.prefix, key, value)
     }
 }
 

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -6,7 +6,7 @@ use cosmwasm::errors::Result;
 use cosmwasm::traits::{ReadonlyStorage, Storage};
 
 use crate::namespace_helpers::key_prefix;
-use crate::type_helpers::{deserialize, may_deserialize, serialize};
+use crate::type_helpers::{may_deserialize, must_deserialize, serialize};
 
 // singleton is a helper function for less verbose usage
 pub fn singleton<'a, S: Storage, T>(storage: &'a mut S, key: &[u8]) -> Singleton<'a, S, T>
@@ -62,7 +62,7 @@ where
     /// load will return an error if no data is set at the given key, or on parse error
     pub fn load(&self) -> Result<T> {
         let value = self.storage.get(&self.key);
-        deserialize(&value)
+        must_deserialize(&value)
     }
 
     /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
@@ -111,7 +111,7 @@ where
     /// load will return an error if no data is set at the given key, or on parse error
     pub fn load(&self) -> Result<T> {
         let value = self.storage.get(&self.key);
-        deserialize(&value)
+        must_deserialize(&value)
     }
 
     /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -7,7 +7,7 @@ use cosmwasm::errors::{NotFound, ParseErr, Result, SerializeErr};
 use cosmwasm::serde::{from_slice, to_vec};
 use cosmwasm::traits::{ReadonlyStorage, Storage};
 
-use crate::prefix::key_prefix;
+use crate::namespace_helpers::key_prefix;
 
 // singleton is a helper function for less verbose usage
 pub fn singleton<'a, S: Storage, T>(storage: &'a mut S, key: &[u8]) -> Singleton<'a, S, T>

--- a/src/type_helpers.rs
+++ b/src/type_helpers.rs
@@ -43,6 +43,7 @@ pub fn deserialize<T: DeserializeOwned + NamedType>(value: &Option<Vec<u8>>) -> 
 #[cfg(test)]
 mod test {
     use super::*;
+    use cosmwasm::errors::Error;
     use named_type_derive::NamedType;
     use serde::{Deserialize, Serialize};
 
@@ -69,5 +70,18 @@ mod test {
 
         let may_parse: Option<Data> = may_deserialize(&loaded).unwrap();
         assert_eq!(may_parse, Some(data));
+    }
+
+    #[test]
+    fn handle_none() {
+        let may_parse = may_deserialize::<Data>(&None).unwrap();
+        assert_eq!(may_parse, None);
+
+        let parsed = deserialize::<Data>(&None);
+        match parsed {
+            Err(Error::NotFound { kind }) => assert_eq!(kind, "Data"),
+            Err(e) => panic!("Unexpected error {}", e),
+            Ok(_) => panic!("should error"),
+        }
     }
 }

--- a/src/type_helpers.rs
+++ b/src/type_helpers.rs
@@ -1,0 +1,73 @@
+use named_type::NamedType;
+use serde::{de::DeserializeOwned, ser::Serialize};
+use snafu::ResultExt;
+
+use cosmwasm::errors::{NotFound, ParseErr, Result, SerializeErr};
+use cosmwasm::serde::{from_slice, to_vec};
+
+/// serialize makes json bytes, but returns a cosmwasm::Error
+pub fn serialize<T: Serialize + NamedType>(data: &T) -> Result<Vec<u8>> {
+    to_vec(data).context(SerializeErr {
+        kind: T::short_type_name(),
+    })
+}
+
+/// may_deserialize parses json bytes from storage (Option), returning Ok(None) if no data present
+///
+/// value is an odd type, but this is meant to be easy to use with output from storage.get (Option<Vec<u8>>)
+/// and value.map(|s| s.as_slice()) seems trickier than &value
+pub fn may_deserialize<T: DeserializeOwned + NamedType>(
+    value: &Option<Vec<u8>>,
+) -> Result<Option<T>> {
+    match value {
+        Some(d) => from_slice(d).context(ParseErr {
+            kind: T::short_type_name(),
+        }),
+        None => Ok(None),
+    }
+}
+
+/// deserialize parses json bytes from storage (Option), returning NotFound error if no data present
+pub fn deserialize<T: DeserializeOwned + NamedType>(value: &Option<Vec<u8>>) -> Result<T> {
+    match value {
+        Some(d) => from_slice(d).context(ParseErr {
+            kind: T::short_type_name(),
+        }),
+        None => NotFound {
+            kind: T::short_type_name(),
+        }
+        .fail(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use named_type_derive::NamedType;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, NamedType, PartialEq, Debug)]
+    struct Data {
+        pub name: String,
+        pub age: i32,
+    }
+
+    #[test]
+    fn serialize_and_deserialize() {
+        // save data
+        let data = Data {
+            name: "Maria".to_string(),
+            age: 42,
+        };
+        let value = serialize(&data).unwrap();
+        let loaded = Some(value);
+
+        //        let parsed: Data = deserialize(loaded.map(|s| s.as_slice())).unwrap();
+        //        assert_eq!(parsed, data);
+        let parsed: Data = deserialize(&loaded).unwrap();
+        assert_eq!(parsed, data);
+
+        let may_parse: Option<Data> = may_deserialize(&loaded).unwrap();
+        assert_eq!(may_parse, Some(data));
+    }
+}

--- a/src/type_helpers.rs
+++ b/src/type_helpers.rs
@@ -20,7 +20,7 @@ pub(crate) fn may_deserialize<T: DeserializeOwned + NamedType>(
     value: &Option<Vec<u8>>,
 ) -> Result<Option<T>> {
     match value {
-        Some(d) => deserialize(d.as_slice()),
+        Some(d) => Ok(Some(deserialize(d.as_slice())?)),
         None => Ok(None),
     }
 }

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use cosmwasm::errors::Result;
 use cosmwasm::traits::{ReadonlyStorage, Storage};
 
-use crate::type_helpers::{deserialize, may_deserialize, serialize};
+use crate::type_helpers::{may_deserialize, must_deserialize, serialize};
 
 pub fn typed<S: Storage, T>(storage: &mut S) -> TypedStorage<S, T>
 where
@@ -50,7 +50,7 @@ where
     /// load will return an error if no data is set at the given key, or on parse error
     pub fn load(&self, key: &[u8]) -> Result<T> {
         let value = self.storage.get(key);
-        deserialize(&value)
+        must_deserialize(&value)
     }
 
     /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.
@@ -95,7 +95,7 @@ where
     /// load will return an error if no data is set at the given key, or on parse error
     pub fn load(&self, key: &[u8]) -> Result<T> {
         let value = self.storage.get(key);
-        deserialize(&value)
+        must_deserialize(&value)
     }
 
     /// may_load will parse the data stored at the key if present, returns Ok(None) if no data there.


### PR DESCRIPTION
I wanted to add a Bucket type that grouped together PrefixedStorage and TypedStorage into one object, as that is a very typical use case. Unfortunately, while the current design does allow you to create two local variables, it seems impossible to create something returnable (eg. PrefixedStorage is garbage collected or there are two references).

This this Bucket is key to making address-based contracts, eg. erc20, easy to use, I want to create such a type. This involved turning most of the methods into functions for a different style of reuse.