### PR TITLE
Add may_update method to Bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# CHANGELOG
+
+## v0.2.0
+
+* BREAKING: `Bucket.update()`` callback takes `Option<T>` not just `T`, allow it to work on unset values
+
+## v0.1.1
+
+* Refactor structs to center around reusable functions, rather than copied methods
+* Create Bucket to join PrefixedStorage and TypedStorage in one object
+
+## v0.1.0
+
+* Basic release with prefix stores, sequence, etc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-storage"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Ethan Frey <ethanfrey@users.noreply.github.com>"]
 edition = "2018"
 description = "CosmWasm library with useful helpers for Storage patterns"

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -135,10 +135,11 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use cosmwasm::errors::contract_err;
+    use cosmwasm::errors::{contract_err, NotFound};
     use cosmwasm::mock::MockStorage;
     use named_type_derive::NamedType;
     use serde::{Deserialize, Serialize};
+    use snafu::OptionExt;
 
     #[derive(Serialize, Deserialize, NamedType, PartialEq, Debug, Clone)]
     struct Data {
@@ -236,7 +237,7 @@ mod test {
 
         // it's my birthday
         let birthday = |mayd: Option<Data>| -> Result<Data> {
-            let mut d = mayd.unwrap();
+            let mut d = mayd.context(NotFound { kind: "Data" })?;
             d.age += 1;
             Ok(d)
         };

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -265,9 +265,7 @@ mod test {
         bucket.save(b"maria", &init).unwrap();
 
         // it's my birthday
-        let output = bucket.update(b"maria", &|_d| {
-            contract_err("cuz i feel like it")
-        });
+        let output = bucket.update(b"maria", &|_d| contract_err("cuz i feel like it"));
         assert!(output.is_err());
 
         // load it properly
@@ -286,12 +284,12 @@ mod test {
         };
 
         // it's my birthday
-        let output = bucket.update(b"maria", &|d| {
-            match d {
+        let output = bucket
+            .update(b"maria", &|d| match d {
                 Some(_) => contract_err("Ensure this was empty"),
                 None => Ok(init_value.clone()),
-            }
-        }).unwrap();
+            })
+            .unwrap();
         assert_eq!(output, init_value);
 
         // nothing stored


### PR DESCRIPTION
This method works like `update`, but handles the case where:

* There is no pre-existing value at the key (we get None)
* We don't want to update after all (no error, just leave it)

This is like `update` but uses `Option<T>` instead of `T` everywhere.

Questions: 
* Do we need to update the return value as well? or just allow accept option?
* For Singleton, we can assume the object exists before, for Bucket not so... maybe we just update the action for `Bucket.update` to `|Option<T>| -> Result<T>` and always support non-existent accounts, and always do a save. I think this would be better... but would be a breaking 0.2.0 release