### PR TITLE
Remove named type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,3 @@ cosmwasm = "~0.6.1"
 serde = { version = "~1.0.103", default-features = false, features = ["derive", "alloc"] }
 snafu = { version = "~0.5.0", default-features = false, features = ["rust_1_30"] }
 schemars = "~0.5"
-named_type = "=0.2.1"
-named_type_derive = "=0.2.1"

--- a/README.md
+++ b/README.md
@@ -153,10 +153,16 @@ pub struct Config {
 
 fn initialize() -> Result<()> {
     let mut store = MockStorage::new();
-    singleton(&mut store, b"config").save(&Config{
+    let config = singleton(&mut store, b"config");
+    config.save(&Config{
         purchase_price: Some(coin("5", "FEE")),
         transfer_price: None,
     })?;
+    config.update(|mut cfg| {
+        cfg.transfer_price = Some(coin(2, "FEE"));
+        Ok(cfg)
+    })?;
+    let loaded = config.load()?;
     OK(())
 }
 ```

--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ CosmWasm library with useful helpers for Storage patterns.
 This is not in the core library, so feel free to fork it and modify or extend as desired for your contracts.
 Pull Requests back to upstream repo with new or improved features are always welcome.
 
+Requires Rust v1.38+ (for `std::any::type_name` used to generate serialization error messages)
+
+Compatible with CosmWasm v0.6.0+
+
 ## Contents
 
 * [PrefixedStorage](#prefixed-storage)
 * [TypedStoreage](#typed-storage)
+* [Bucket](#bucket)
+* [Singleton](#singleton)
 
 ### Prefixed Storage
 
@@ -98,5 +104,68 @@ let expected = Data {
 assert_eq!(output, expected);
 ``` 
 
+### Bucket
+
+Since the above idiom (a subspace for a class of items) is so common and useful, 
+and there is no easy way to return this from a function 
+(bucket holds a reference to space, and cannot live longer than the local variable), the two are often
+combined into a `Bucket`. A Bucket works just like the example above, except the creation can be
+in another function:
+
+```rust
+use cosmwasm::mock::MockStorage;
+use cw_storage::{bucket, Bucket};
+
+fn people<'a, S: Storage>(storage: &'a mut S) -> Bucket<'a, S, Data> {
+    bucket(b"people", storage)
+}
+
+fn do_stuff() -> Result <()> {
+    let mut store = MockStorage::new();
+    people(&mut store).save(b"john", &Data{
+        name: "John",
+        age: 314,
+    })?;
+    OK(())
+}
+```
+
+### Singleton
+
+Singleton is another wrapper around the `TypedStorage` API. There are cases when we don't need
+a whole subspace to hold arbitrary key-value lookup for typed data, but rather one single instance.
+The simplest example is some *configuration* information for a contract. For example, in the 
+[name service example](https://github.com/confio/cosmwasm-examples/tree/master/nameservice),
+there is a `Bucket` to look up name to name data, but we also have a `Singleton` to store
+global configuration - namely the price of buying a name.
+
+```rust
+use cosmwasm::mock::MockStorage;
+use cosmwasm::types::{Coin, coin};
+
+use cw_storage::{singleton};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema, NamedType)]
+pub struct Config {
+    pub purchase_price: Option<Coin>,
+    pub transfer_price: Option<Coin>,
+}
+
+fn initialize() -> Result<()> {
+    let mut store = MockStorage::new();
+    singleton(&mut store, b"config").save(&Config{
+        purchase_price: Some(coin("5", "FEE")),
+        transfer_price: None,
+    })?;
+    OK(())
+}
+```
+
+`Singleton` works just like `Bucket`, except the `save`, `load`, `update` methods don't take
+a key, and `update` requires the object to already exist (use `save` the first time).
+For `Buckets`, we often don't know which keys exist, but `Singletons` should be
+initialized when the contract is instantiated.
+
 Since the heart of much of the smart contract code is simply transformations upon some stored state,
-We may be able to just code the transforms and let the `TypedStorage` APIs take care of all the boilerplate.
+We may be able to just code the state transitions and let the `TypedStorage` APIs take care of all
+the boilerplate.

--- a/src/bucket.rs
+++ b/src/bucket.rs
@@ -1,4 +1,3 @@
-use named_type::NamedType;
 use serde::{de::DeserializeOwned, ser::Serialize};
 use std::marker::PhantomData;
 
@@ -10,7 +9,7 @@ use crate::type_helpers::{may_deserialize, must_deserialize, serialize};
 
 pub fn bucket<'a, S: Storage, T>(namespace: &[u8], storage: &'a mut S) -> Bucket<'a, S, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     Bucket::new(namespace, storage)
 }
@@ -20,14 +19,14 @@ pub fn bucket_read<'a, S: ReadonlyStorage, T>(
     storage: &'a S,
 ) -> ReadonlyBucket<'a, S, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     ReadonlyBucket::new(namespace, storage)
 }
 
 pub struct Bucket<'a, S: Storage, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     storage: &'a mut S,
     // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
@@ -37,7 +36,7 @@ where
 
 impl<'a, S: Storage, T> Bucket<'a, S, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     pub fn new(namespace: &[u8], storage: &'a mut S) -> Self {
         Bucket {
@@ -90,7 +89,7 @@ where
 
 pub struct ReadonlyBucket<'a, S: ReadonlyStorage, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     storage: &'a S,
     // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
@@ -100,7 +99,7 @@ where
 
 impl<'a, S: ReadonlyStorage, T> ReadonlyBucket<'a, S, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     pub fn new(namespace: &[u8], storage: &'a S) -> Self {
         ReadonlyBucket {
@@ -137,11 +136,10 @@ mod test {
     use super::*;
     use cosmwasm::errors::{contract_err, NotFound};
     use cosmwasm::mock::MockStorage;
-    use named_type_derive::NamedType;
     use serde::{Deserialize, Serialize};
     use snafu::OptionExt;
 
-    #[derive(Serialize, Deserialize, NamedType, PartialEq, Debug, Clone)]
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
     struct Data {
         pub name: String,
         pub age: i32,

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1,6 +1,4 @@
 // derive macros
-use named_type::NamedType;
-use named_type_derive::NamedType;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +11,7 @@ use crate::Singleton;
 /// but mainly to be able to derive NamedType.
 /// If named_type included a default derivation for u64 and other primitives, we could
 /// just use a u64 here.
-#[derive(Serialize, Deserialize, Copy, Clone, Default, Debug, PartialEq, JsonSchema, NamedType)]
+#[derive(Serialize, Deserialize, Copy, Clone, Default, Debug, PartialEq, JsonSchema)]
 pub struct SeqVal(pub u64);
 
 /// Sequence creates a custom Singleton to hold an empty sequence

--- a/src/singleton.rs
+++ b/src/singleton.rs
@@ -1,4 +1,3 @@
-use named_type::NamedType;
 use serde::{de::DeserializeOwned, ser::Serialize};
 use std::marker::PhantomData;
 
@@ -11,7 +10,7 @@ use crate::type_helpers::{may_deserialize, must_deserialize, serialize};
 // singleton is a helper function for less verbose usage
 pub fn singleton<'a, S: Storage, T>(storage: &'a mut S, key: &[u8]) -> Singleton<'a, S, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     Singleton::new(storage, key)
 }
@@ -22,7 +21,7 @@ pub fn singleton_read<'a, S: ReadonlyStorage, T>(
     key: &[u8],
 ) -> ReadonlySingleton<'a, S, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     ReadonlySingleton::new(storage, key)
 }
@@ -33,7 +32,7 @@ where
 /// TypedStorage accessors, without requiring a key (which is defined in the constructor)
 pub struct Singleton<'a, S: Storage, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     storage: &'a mut S,
     key: Vec<u8>,
@@ -43,7 +42,7 @@ where
 
 impl<'a, S: Storage, T> Singleton<'a, S, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     pub fn new(storage: &'a mut S, key: &[u8]) -> Self {
         Singleton {
@@ -88,7 +87,7 @@ where
 /// methods of Singleton that don't modify state.
 pub struct ReadonlySingleton<'a, S: ReadonlyStorage, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     storage: &'a S,
     key: Vec<u8>,
@@ -98,7 +97,7 @@ where
 
 impl<'a, S: ReadonlyStorage, T> ReadonlySingleton<'a, S, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     pub fn new(storage: &'a S, key: &[u8]) -> Self {
         ReadonlySingleton {
@@ -126,12 +125,11 @@ where
 mod test {
     use super::*;
     use cosmwasm::mock::MockStorage;
-    use named_type_derive::NamedType;
     use serde::{Deserialize, Serialize};
 
     use cosmwasm::errors::{Error, Unauthorized};
 
-    #[derive(Serialize, Deserialize, NamedType, PartialEq, Debug)]
+    #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct Config {
         pub owner: String,
         pub max_tokens: i32,

--- a/src/type_helpers.rs
+++ b/src/type_helpers.rs
@@ -86,7 +86,9 @@ mod test {
         let parsed = must_deserialize::<Data>(&None);
         match parsed {
             // if we used short_type_name, this would just be Data
-            Err(Error::NotFound { kind }) => assert_eq!(kind, "cw_storage::type_helpers::test::Data"),
+            Err(Error::NotFound { kind }) => {
+                assert_eq!(kind, "cw_storage::type_helpers::test::Data")
+            }
             Err(e) => panic!("Unexpected error {}", e),
             Ok(_) => panic!("should error"),
         }

--- a/src/type_helpers.rs
+++ b/src/type_helpers.rs
@@ -4,10 +4,15 @@ use snafu::ResultExt;
 use cosmwasm::errors::{NotFound, ParseErr, Result, SerializeErr};
 use cosmwasm::serde::{from_slice, to_vec};
 
+pub fn short_type_name<T>() -> &'static str {
+    let long = std::any::type_name::<T>();
+    long.rsplit("::").next().unwrap_or(long)
+}
+
 /// serialize makes json bytes, but returns a cosmwasm::Error
 pub fn serialize<T: Serialize>(data: &T) -> Result<Vec<u8>> {
     to_vec(data).context(SerializeErr {
-        kind: T::type_name(),
+        kind: short_type_name::<T>(),
     })
 }
 
@@ -27,7 +32,7 @@ pub(crate) fn must_deserialize<T: DeserializeOwned>(value: &Option<Vec<u8>>) -> 
     match value {
         Some(d) => deserialize(&d),
         None => NotFound {
-            kind: T::type_name(),
+            kind: short_type_name::<T>(),
         }
         .fail(),
     }
@@ -36,7 +41,7 @@ pub(crate) fn must_deserialize<T: DeserializeOwned>(value: &Option<Vec<u8>>) -> 
 // deserialize is a reflection of serialize and probably what most people outside the crate expect
 pub fn deserialize<T: DeserializeOwned>(value: &[u8]) -> Result<T> {
     from_slice(value).context(ParseErr {
-        kind: T::type_name(),
+        kind: short_type_name::<T>(),
     })
 }
 

--- a/src/typed.rs
+++ b/src/typed.rs
@@ -1,4 +1,3 @@
-use named_type::NamedType;
 use serde::{de::DeserializeOwned, ser::Serialize};
 use std::marker::PhantomData;
 
@@ -9,21 +8,21 @@ use crate::type_helpers::{may_deserialize, must_deserialize, serialize};
 
 pub fn typed<S: Storage, T>(storage: &mut S) -> TypedStorage<S, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     TypedStorage::new(storage)
 }
 
 pub fn typed_read<S: ReadonlyStorage, T>(storage: &S) -> ReadonlyTypedStorage<S, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     ReadonlyTypedStorage::new(storage)
 }
 
 pub struct TypedStorage<'a, S: Storage, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     storage: &'a mut S,
     // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
@@ -32,7 +31,7 @@ where
 
 impl<'a, S: Storage, T> TypedStorage<'a, S, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     pub fn new(storage: &'a mut S) -> Self {
         TypedStorage {
@@ -74,7 +73,7 @@ where
 
 pub struct ReadonlyTypedStorage<'a, S: ReadonlyStorage, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     storage: &'a S,
     // see https://doc.rust-lang.org/std/marker/struct.PhantomData.html#unused-type-parameters for why this is needed
@@ -83,7 +82,7 @@ where
 
 impl<'a, S: ReadonlyStorage, T> ReadonlyTypedStorage<'a, S, T>
 where
-    T: Serialize + DeserializeOwned + NamedType,
+    T: Serialize + DeserializeOwned,
 {
     pub fn new(storage: &'a S) -> Self {
         ReadonlyTypedStorage {
@@ -111,13 +110,12 @@ mod test {
     use super::*;
     use cosmwasm::errors::{contract_err, NotFound};
     use cosmwasm::mock::MockStorage;
-    use named_type_derive::NamedType;
     use serde::{Deserialize, Serialize};
     use snafu::OptionExt;
 
     use crate::prefixed;
 
-    #[derive(Serialize, Deserialize, NamedType, PartialEq, Debug, Clone)]
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
     struct Data {
         pub name: String,
         pub age: i32,


### PR DESCRIPTION
Closes #9 

This uses `std::any::type_name` instead, along with a short parse step to get the same short names as now, so we keep getting `Data` rather than `cw_storage::type_helpers::test::Data` (or `HandleMsg` rather than `cw-erc20::msgs::HandleMsg`). I assume the short form is nicer for error messages, but can enable the long form as well.